### PR TITLE
Moment.js 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the following directive to your Javascript manifest file (application.js):
 
 ## Versioning
 
-momentjs-rails 1.4.0 == Moment.js 1.4.0
+momentjs-rails 1.5.0 == Moment.js 1.5.0
 
 Every attempt is made to mirror the currently shipping Momentum.js version number wherever possible.
 The major and minor version numbers will always represent the Momentum.js version, but the patch level

--- a/changelog.md
+++ b/changelog.md
@@ -3,3 +3,6 @@
 
 ### Version 1.4.0 (2012-02-09)
 - Upgraded Moment.js to 1.4.0
+
+### Version 1.5.0 (2012-03-30)
+- Upgraded Moment.js to 1.5.0

--- a/momentjs-rails.gemspec
+++ b/momentjs-rails.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "momentjs-rails"
-  s.version     = "1.4.0"
+  s.version     = "1.5.0"
   s.authors     = ["Derek Prior"]
   s.homepage    = "https://github.com/derekprior/momentjs-rails"
   s.summary     = "The Moment.js JavaScript library ready to play with Rails."


### PR DESCRIPTION
Hi Derek,

Thank you for providing this asset gem! It looks like Moment.js released v1.5.0 a couple weeks ago. It adds UTC support as well as automatic cross-browser ISO-8601 support. I was wondering if you could update the gem in the repo as well as RubyGems.

Updates:
- moment.js file now mirrors moment.js from timrwood / moment tag v.1.5.0
- README.me now refers to 1.5.0 instead of 1.4.0
- changelog.md reflects the update
- gemspec now has the new version number

Thanks,
Mike
