### PR TITLE
Add Rails 4 compatibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,3 +18,6 @@
 ### Version 1.7.2 (2012-12-17)
 - Upgrade Moment.js to 1.7.2
 - Upgrade localization files to 1.7.2 tagged versions.
+
+### Version 1.7.3 (2013-01-30)
+- Rails 4 compatibility

--- a/momentjs-rails.gemspec
+++ b/momentjs-rails.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "momentjs-rails"
-  s.version     = "1.7.2"
+  s.version     = "1.7.3"
   s.authors     = ["Derek Prior"]
   s.homepage    = "https://github.com/derekprior/momentjs-rails"
   s.summary     = "The Moment.js JavaScript library ready to play with Rails."
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{lib,vendor}/**/*"] + ["changelog.md", "MIT-LICENSE", "README.md"]
 
-  s.add_dependency "railties", "~> 3.1"
+  s.add_dependency "railties", ">= 3.1", "< 4.1"
 end


### PR DESCRIPTION
A simple update to the Gemspec to allow any version of Rails above 3.1 and below 4.1.
